### PR TITLE
Update resolver.js

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -73,6 +73,8 @@ Resolver.prototype.dereferenceSchema = function (schema, context, prop, stack) {
       this._debug(3, 'Found $ref: %s in %s - Resolving...', item, context);
       // Resolve schema or definition reference (throws if it can't find it)
       resolved = this._resolvePointer(item, context);
+      // Remove links property to avoid infinite recursion when referencing parent schema in links.schema and links.targetSchema
+      resolved = _.omit(resolved, "links");
       // Assign the resolved reference as the schema for this prop/stack loop.
       // Pass along the resolved ID if it's a valid schema, to
       // force a context change when recursing
@@ -118,6 +120,10 @@ Resolver.prototype.dereferenceSchema = function (schema, context, prop, stack) {
  * @private
  */
 Resolver.prototype._normalizeReference = function (reference, context) {
+  //Check for self reference
+  if (reference === INTERNAL_SCHEMA_REFERENCE_SEPARATOR) {
+      return context;
+  }
   // Split apart the references to get the external and internal references
   var referenceComponents = reference.split(INTERNAL_SCHEMA_REFERENCE_SEPARATOR);
   var contextComponents = _.isString(context) ? context.split(INTERNAL_SCHEMA_REFERENCE_SEPARATOR) : [];


### PR DESCRIPTION
Small fix to avoid infinite recursion problems when referencing the root schema from the links.schema and links.targetSchema objects. (This is achieved by omitting the links property from the schema within the dereferenceSchema method).

Allows one to use "$ref" : "#" to reference the root schema
