### PR TITLE
Fix typos in example product.json schema:

### DIFF
--- a/examples/ecommerce/schemas/product.json
+++ b/examples/ecommerce/schemas/product.json
@@ -66,8 +66,8 @@
         "price": {"$ref": "#/definitions/price"},
         "currency": {"$ref": "#/definitions/currency"},
         "in_stock": {"$ref": "#/definitions/in_stock"},
-        "available_qty": {"$ref": "#/definitions/avaiable_qty"},
-        "image": {"$ref": "#/definitions/image"},
+        "available_qty": {"$ref": "#/definitions/available_qty"},
+        "image": {"$ref": "#/definitions/image"}
     },
 
     "additionalProperties": {


### PR DESCRIPTION
- remove dangling comma
- fix typo in available_qty
