### PR TITLE
Prevent handlebars auto indenting

### DIFF
--- a/drivers/template.js
+++ b/drivers/template.js
@@ -86,7 +86,7 @@ TemplateDriver.prototype._transform = function(templates) {
  */
 TemplateDriver.prototype._compile = function(templates) {
   templates = _.mapValues(templates, function(str) {
-    return Handlebars.compile(str);
+    return Handlebars.compile(str, {preventIndent: true});
   });
   // Register each template as a partial, so they can be included in each other
   _.each(templates, function(source, name) {


### PR DESCRIPTION
The master (version 1.x.x) of `json-schema-docs-generator` breaks indentation of our code examples. The reason is the upgrade of handlebars from `v2.0.0-alpha.4` which was the last version without the auto indenting functionality.

There is a long issue tracking this problem: https://github.com/wycats/handlebars.js/issues/858
They've introduced `preventIndent` flag (http://handlebarsjs.com/reference.html).

Also, it makes `<pre>` unusable but we need it in order to bypass CF HTML minimization.
