### PR TITLE
Better (whitelisting) sanitization for HTML IDs.

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -66,7 +66,7 @@ Transformer.prototype.transformSchema = function(schema, driver) {
  * @return {String}
  */
 Transformer.prototype._sanitizeHTMLID = function(str) {
-  return (str || '').toString().toLowerCase().replace(/[#\'\(\) ]+/gi, '-');
+  return (str || '').toString().toLowerCase().replace(/[^a-z0-9]+/gi, '-');
 };
 
 /**


### PR DESCRIPTION
This sanitizes everything but letters and numbers.

// Sometimes we use characters like `.` or `/` in our schema titles and it breaks jQuery navigation.
