### PR TITLE
Sorting by composer options

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -76,8 +76,10 @@ Composer.prototype.composePage = function(page, schemas, templates) {
 Composer.prototype.getPageTemplateData = function(page, schemas, templates) {
   // Map schema IDs to the full schemas for data access in the templates
   _.each(page.sections, function(section) {
-    section.schemas = _.filter(schemas, function(schema) {
-      return _.contains(section.schemas, schema.id);
+    section.schemas = _.map(section.schemas, function(schema) {
+      return _.find(schemas, function(_schema) {
+        return _schema.id === schema;
+      });
     });
   });
 

--- a/lib/helpers/curl.js
+++ b/lib/helpers/curl.js
@@ -60,11 +60,7 @@ module.exports = {
    */
   buildFlag: function(type, value, indents, quoteType) {
     quoteType = !_.isUndefined(quoteType) ? quoteType : '"';
-    var prefix = '-';
-    for (var i = 0; i < indents; i++){
-      prefix = ' ' + prefix;
-    }
-    return [prefix, type, ' ', quoteType, value, quoteType].join('');
+    return [_.repeat(' ', indents) + '-', type, ' ', quoteType, value, quoteType].join('');
   },
 
   /**

--- a/lib/helpers/curl.js
+++ b/lib/helpers/curl.js
@@ -26,17 +26,17 @@ module.exports = {
     var str;
 
     method = method || 'GET';
-    str = ['curl', this.buildFlag('X', method.toUpperCase(), ''), '"' + uri + '"'].join(' ');
+    str = ['curl', this.buildFlag('X', method.toUpperCase(), 0, ''), '"' + uri + '"'].join(' ');
 
     _.each(headers, function(val, header) {
-      flags.push(this.buildFlag('H', header + config.HEADER_SEPARATOR + val));
+      flags.push(this.buildFlag('H', header + config.HEADER_SEPARATOR + val, 5));
     }, this);
 
     if (data) {
       if (method.toLowerCase() === 'get') {
         str += this.buildQueryString(data);
       } else {
-        flags.push(this.buildFlag('-data', this.formatData(data), '\''));
+        flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
       }
     }
 
@@ -54,12 +54,17 @@ module.exports = {
   /**
    * @param {String} type
    * @param {String} value
+   * @param {Number} indents
    * @param {String} [quoteType=\"]
    * @returns {String}
    */
-  buildFlag: function(type, value, quoteType) {
+  buildFlag: function(type, value, indents, quoteType) {
     quoteType = !_.isUndefined(quoteType) ? quoteType : '"';
-    return ['-', type, ' ', quoteType, value, quoteType].join('');
+    var prefix = '-';
+    for (var i = 0; i < indents; i++){
+      prefix = ' ' + prefix;
+    }
+    return [prefix, type, ' ', quoteType, value, quoteType].join('');
   },
 
   /**

--- a/test/lib/helpers/curl.js
+++ b/test/lib/helpers/curl.js
@@ -49,15 +49,19 @@ describe('cURL Helper', function() {
 
   describe('#buildFlag', function() {
     it('should allow wrapping the value in nothing', function() {
-      expect(curl.buildFlag('X', 'GET', '')).to.equal('-X GET');
+      expect(curl.buildFlag('X', 'GET', 0, '')).to.equal('-X GET');
     });
 
     it('should wrap the value in double quotes by default', function() {
-      expect(curl.buildFlag('H', 'value')).to.equal('-H "value"');
+      expect(curl.buildFlag('H', 'value', 0)).to.equal('-H "value"');
     });
 
     it('should wrap the value in the specified type', function() {
-      expect(curl.buildFlag('H', 'value', '\'')).to.equal('-H \'value\'');
+      expect(curl.buildFlag('H', 'value', 0, '\'')).to.equal('-H \'value\'');
+    });
+
+    it('should prepend extra 5 spaces', function() {
+      expect(curl.buildFlag('H', 'value', 5)).to.equal('     -H "value"');
     });
   });
 


### PR DESCRIPTION
Right now, the final order of schemas seems to be random (based on file system). It should respect our settings (third parameter) for composer (aka `options.pages.sections.schemas` array).
