### PR TITLE
Final ordering should respect composer options (correct branch)

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -76,8 +76,10 @@ Composer.prototype.composePage = function(page, schemas, templates) {
 Composer.prototype.getPageTemplateData = function(page, schemas, templates) {
   // Map schema IDs to the full schemas for data access in the templates
   _.each(page.sections, function(section) {
-    section.schemas = _.filter(schemas, function(schema) {
-      return _.contains(section.schemas, schema.id);
+    section.schemas = _.map(section.schemas, function(schema) {
+      return _.find(schemas, function(_schema) {
+        return _schema.id === schema;
+      });
     });
   });
 


### PR DESCRIPTION
Right now, the final order of schemas seems to be random (based on file system). It should respect our settings (third parameter) for composer (aka `options.pages.sections.schemas` array).
