### PR TITLE
cURL header generation bugfixes

### DIFF
--- a/lib/helpers/curl.js
+++ b/lib/helpers/curl.js
@@ -26,18 +26,21 @@ module.exports = {
     var str;
 
     method = method || 'GET';
+
+    if (data && method.toLowerCase() === 'get') {
+      uri += this.buildQueryString(data);
+    }
+
     str = ['curl', this.buildFlag('X', method.toUpperCase(), 0, ''), '"' + uri + '"'].join(' ');
 
-    _.each(headers, function(val, header) {
-      flags.push(this.buildFlag('H', header + config.HEADER_SEPARATOR + val, 5));
-    }, this);
+    if (headers) {
+      _.each(headers.properties, function(val, header) {
+        flags.push(this.buildFlag('H', header + config.HEADER_SEPARATOR + val.example, 5));
+      }, this);
+    }
 
-    if (data) {
-      if (method.toLowerCase() === 'get') {
-        str += this.buildQueryString(data);
-      } else {
-        flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
-      }
+    if (data && method.toLowerCase() !== 'get') {
+      flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
     }
 
     return str + config.NEW_LINE + flags.join(config.NEW_LINE);

--- a/lib/helpers/curl.js
+++ b/lib/helpers/curl.js
@@ -34,8 +34,8 @@ module.exports = {
     str = ['curl', this.buildFlag('X', method.toUpperCase(), 0, ''), '"' + uri + '"'].join(' ');
 
     if (headers) {
-      _.each(headers.properties, function(val, header) {
-        flags.push(this.buildFlag('H', header + config.HEADER_SEPARATOR + val.example, 5));
+      _.each(headers, function(val, header) {
+        flags.push(this.buildFlag('H', header + config.HEADER_SEPARATOR + val, 5));
       }, this);
     }
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -27,6 +27,15 @@ var Transformer = function(schemas, options) {
   this.options = options;
   this.formatter = options.formatter || JSONformatter;
   this.schemas = schemas;
+  var schemaPages = {};
+  _.forEach(this.options.pages, function(page, pageIndex) {
+    _.forEach(page.sections, function(section) {
+      _.forEach(section.schemas, function(schema) {
+        schemaPages[schema] = pageIndex;
+      });
+    });
+  });
+  this.schemaPages = schemaPages;
   // Used for looking up references within URIs
   // (and maybe other things at some point?)
   this._resolver = new Resolver(_.values(schemas), options);
@@ -138,9 +147,13 @@ Transformer.prototype.buildHref = function(href, schema, withExampleData) {
  * @returns {String}
  */
 Transformer.prototype.buildCurl = function (link, schema) {
-  var baseUrl = _.get(this, 'options.curl.baseUrl') || '';
+  var page = {};
+  if (typeof this.schemaPages[schema.id] !== 'undefined') {
+    page = this.options.pages[this.schemaPages[schema.id]];
+  }
+  var baseUrl = _.get(page, 'curl.baseUrl') || '';
   var uri = baseUrl + this.buildHref(link.href, schema, true);
-  var headers = link.requestHeaders || _.get(this, 'options.curl.requestHeaders');
+  var headers = link.requestHeaders || _.get(page, 'curl.requestHeaders');
   var data = link.schemaExampleData;
 
   if (link.schema) {

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -148,12 +148,20 @@ Transformer.prototype.buildHref = function(href, schema, withExampleData) {
  */
 Transformer.prototype.buildCurl = function (link, schema) {
   var page = {};
+  var headers = {};
   if (typeof this.schemaPages[schema.id] !== 'undefined') {
     page = this.options.pages[this.schemaPages[schema.id]];
   }
   var baseUrl = _.get(page, 'curl.baseUrl') || '';
   var uri = baseUrl + this.buildHref(link.href, schema, true);
-  var headers = link.requestHeaders || _.get(page, 'curl.requestHeaders');
+
+  if (_.get(page, 'curl.requestHeaders')) {
+    headers = exampleExtractor.extract(_.get(page, 'curl.requestHeaders'), schema);
+  }
+  if (link.requestHeaders) {
+    headers = exampleExtractor.extract(link.requestHeaders, schema);
+  }
+
   var data = link.schemaExampleData;
 
   if (link.schema) {

--- a/test/lib/helpers/curl.js
+++ b/test/lib/helpers/curl.js
@@ -23,11 +23,7 @@ describe('cURL Helper', function() {
 
     it('should add headers', function() {
       var str = curl.generate('https://api.example.com/url', 'POST', {
-        properties: {
-          'My-Header': {
-            example: 'some value'
-          }
-        }
+        'My-Header': 'some value'
       });
       expect(str).to.contain('My-Header: some value');
     });

--- a/test/lib/helpers/curl.js
+++ b/test/lib/helpers/curl.js
@@ -23,7 +23,11 @@ describe('cURL Helper', function() {
 
     it('should add headers', function() {
       var str = curl.generate('https://api.example.com/url', 'POST', {
-        'My-Header': 'some value'
+        properties: {
+          'My-Header': {
+            example: 'some value'
+          }
+        }
       });
       expect(str).to.contain('My-Header: some value');
     });
@@ -43,7 +47,7 @@ describe('cURL Helper', function() {
         key2: 'value2'
       });
 
-      expect(str).to.contain('?key1=value1&key2=value2');
+      expect(str).to.contain('"https://api.example.com/url?key1=value1&key2=value2"');
     });
   });
 


### PR DESCRIPTION
This PR addresses and fixes these issues:
- defaults specified in options are global only but we need different defaults for each page
- curl generator isn't able to handle specific `link.requestHeaders` that overwrites option defaults
- URIs with GET parameters are broken (the closing `"` was missplaced)
