### PR TITLE
Bugfix of link parameters 

### DIFF
--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -77,7 +77,9 @@ ObjectDefinition.prototype.build = function(object) {
   self.title = object.title;
   self.description = object.description;
   self.requiredProps = _.pick(self.allProps, required);
+  if (_.isEmpty(self.requiredProps)) self.requiredProps = null;
   self.optionalProps = _.omit(self.allProps, required);
+  if (_.isEmpty(self.optionalProps)) self.optionalProps = null;
   self._original = object;
 
   try {

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -99,7 +99,7 @@ Transformer.prototype.transformLink = function(schema, link) {
       htmlID: this._sanitizeHTMLID(schema.title + '-' + link.title),
       uri: this.buildHref(link.href, schema),
       curl: this.buildCurl(link, schema),
-      parameters: link.schema ? this.formatLinkParameters(link.schema, schema) : undefined,
+      parameters: link.schema ? this.formatLinkParameters(link.schema, schema, link.required) : undefined,
       response: link.targetSchema ? this.formatData(this.generateExample(link.targetSchema, schema)) : undefined
     });
   } catch (e) {
@@ -200,10 +200,13 @@ Transformer.prototype.generateExample = function(component, root, options) {
  * @param {Object} schema - Link inputs
  * @returns {ObjectDefinition}
  */
-Transformer.prototype.formatLinkParameters = function(schema, root) {
-  return new ObjectDefinition(schema.rel === 'self' ? root : schema, {
-    formatter: this.formatter
-  });
+Transformer.prototype.formatLinkParameters = function(schema, root, required) {
+  var baseSchema = root;
+  if (schema.rel !== 'self') {
+    baseSchema = schema;
+    baseSchema.required = required;
+  }
+  return this.generateObjectDefinition(baseSchema);
 };
 
 /**


### PR DESCRIPTION
- link parameters were not correctly split into required and optional categories (missing required array)
- if these categories are empty objects, it should be replaced by null, so it works in handlebars conditions
