### PR TITLE
Typo in extractor

### DIFF
--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -89,7 +89,7 @@ ExampleDataExtractor.prototype.mapPropertiesToExamples = function(props, schema,
     } else if (propConfig.id && !example) {
       example = this.extract(propConfig, propConfig);
     } else if (propConfig.properties) {
-      example = this.mapPropertiesToExamples(props.properties, schema);
+      example = this.mapPropertiesToExamples(propConfig.properties, schema);
     } else if (propConfig.oneOf || propConfig.anyOf) {
       example = this.extract(propConfig, schema);
     } else if (propConfig.allOf) {


### PR DESCRIPTION
It didn't extract examples from deep (2nd level+) object properties.
