### PR TITLE
Added custom callback to parse input files

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -33,17 +33,19 @@ getFiles.raw = function (filePaths) {
 
 /**
  * Same as the `.raw()` method, except this method will attempt to parse
- * the file contents as JSON.
+ * the file contents to JavaScript object with provided parser. The parser
+ * will be called with file contents and file name (in that order).
  *
  * @param {array} filePaths
+ * @param {function} callback to parse contents, defaults to JSON parser
  * @returns {Promise}
  */
-getFiles.asJSON = function (filePaths) {
+getFiles.asObjects = function (filePaths, parser) {
   return getFiles.raw(filePaths)
     .then(function(map) {
       return _.mapValues(map, function(str, filePath) {
         try {
-          return JSON.parse(str);
+          return (parser || getFiles.defaultParser)(str, filePath);
         } catch (e) {
           e.filePath = filePath;
           throw e;
@@ -53,6 +55,10 @@ getFiles.asJSON = function (filePaths) {
     .catch(function(e) {
       throw new SyntaxError('Check your JSON syntax. Could not parse file: ' + e.filePath);
     });
+};
+
+getFiles.defaultParser = function (content, filePath) {
+  return JSON.parse(content);
 };
 
 module.exports = getFiles;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,7 +50,7 @@ Parser.prototype.filterPaths = function (paths) {
  * @return {Object}
  */
 Parser.prototype.retreive = function(files) {
-  return getFiles.asJSON(files);
+  return getFiles.asObjects(files, this.options.parser);
 };
 
 /**

--- a/test/lib/get-files.js
+++ b/test/lib/get-files.js
@@ -1,9 +1,13 @@
 'use strict';
 /* globals: describe, it */
 
-var expect = require('chai').expect;
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
 var getFiles = require('../../lib/get-files');
 var fixturesDir = process.cwd() + '/test/fixtures';
+
+chai.use(require('sinon-chai'));
 
 /** @name describe @function */
 /** @name it @function */
@@ -23,12 +27,24 @@ describe('Get files', function() {
     });
   });
 
-  describe('#asJSON', function() {
+  describe('#asObjects', function() {
     it('should return a mapped object of JSON contents, keyed by file name', function() {
-      return getFiles.asJSON([fixturesDir + '/schema1.json', fixturesDir + '/schema2.json']).then(function(map) {
+      return getFiles.asObjects([fixturesDir + '/schema1.json', fixturesDir + '/schema2.json']).then(function(map) {
         expect(map).to.be.an('object');
         expect(map).to.have.property(fixturesDir + '/schema1.json').that.is.an('object');
         expect(map).to.have.property(fixturesDir + '/schema2.json').that.is.an('object');
+      });
+    });
+
+    it('should allow to specify a custom parser, keyed by file name', function() {
+      var cb = sinon.spy(JSON.parse);
+      return getFiles.asObjects([fixturesDir + '/schema1.json', fixturesDir + '/schema2.json'], cb).then(function(map) {
+        expect(map).to.be.an('object');
+        expect(map).to.have.property(fixturesDir + '/schema1.json').that.is.an('object');
+        expect(map).to.have.property(fixturesDir + '/schema2.json').that.is.an('object');
+        expect(cb).to.have.been.calledTwice;
+        expect(cb).to.have.been.calledWithMatch(sinon.match.string, fixturesDir + '/schema1.json');
+        expect(cb).to.have.been.calledWithMatch(sinon.match.string, fixturesDir + '/schema2.json');
       });
     });
   });


### PR DESCRIPTION
This adds a new `parser` argument to schema driver to be able to give a
custom parser instead of the regular JSON one (this is still the
default).

My use case that I have quite lengthy descriptions in my schema which makes easier for me to write them in YAML. The new callback is called with the file name as second argument so the custom parser can figure out what to do depending on file extension for instance.
