### PR TITLE
Fix undefined error message

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -9,9 +9,15 @@ var JSONformatter = require('./formatters/json');
 var exampleExtractor = require('./example-data-extractor');
 var ObjectDefinition = require('./object-definition');
 var colors = require('colors');
+
 var throwError = function(e, msg) {
-  var err = new Error(msg + ': ' + e.message.red);
-  err.stack = e.stack;
+  var err;
+  if (e && e.message) {
+    err = new Error(msg + ': ' + e.message.red);
+    err.stack = e.stack;
+  } else {
+    err = new Error(msg);
+  }
   throw err;
 };
 


### PR DESCRIPTION
@iToto was able to introduce an error in schema that results in undefined `e.message` and that throws another (unwanted) error:

```
Cannot read property 'red' of undefined
```
