### PR TITLE
Preserve referrer's documentation

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -76,7 +76,9 @@ Resolver.prototype.dereferenceSchema = function (schema, context, prop, stack) {
       // Assign the resolved reference as the schema for this prop/stack loop.
       // Pass along the resolved ID if it's a valid schema, to
       // force a context change when recursing
+      const original_description = schema.description;
       schema = this.dereferenceSchema(resolved, this._normalizeReference(item, context), prop, stack);
+      schema.referrer_description = original_description;
       // Quit this loop once we've found a `$ref`
       return false;
     }


### PR DESCRIPTION
When compiling documentation from JSON Schema I have found it useful to preserve referrer's `description` field.

An example:

```
{
    "id": "num",
    "type": "number",
    "description": "num description"
}

{
   "id": "coord",
   "type": "object",
   "properties": {
       "x": {
           "description": "I am the x",
           "$ref": "num"
       },
       "y": {
           "description": "And I am the y!",
           "$ref": "num"
   }
}
```

Later on when I am rendering docs for coord, I want to be able to get `description` defined for `x` and `y`, as well as with `num` substituted in.

Testing:
- Locally in a personal project.
- `npm test` passed.
